### PR TITLE
AtLeastOnceDelivery + Propagation as Futures

### DIFF
--- a/src/main/scala/org/xsc/pure/PureActor.scala
+++ b/src/main/scala/org/xsc/pure/PureActor.scala
@@ -1,10 +1,11 @@
 package org.xsc.pure
 
 import akka.actor.Actor
+import concurrent.Future
 
 object PureActor {
   trait Base[Action, Effect, Response, State] {
-    type Propagate = PartialFunction[Effect, Unit]
+    type Propagate = PartialFunction[Effect, Future[Unit]]
 
     val initialState:    State
     val handleAction:    (State, Action) => (Option[Response], List[Effect])

--- a/src/main/scala/org/xsc/pure/PurePersistentActor.scala
+++ b/src/main/scala/org/xsc/pure/PurePersistentActor.scala
@@ -1,47 +1,82 @@
 package org.xsc.pure
 
-import akka.persistence.PersistentActor
+import akka.persistence.{ PersistentActor, AtLeastOnceDelivery }
+
+object PurePersistentActor {
+  final case class ConfirmableEffect(deliveryId: Long, effect: Any)
+  final case class ConfirmedEffect(deliveryId: Long)
+
+  private def noOp (v: Any) = ()
+}
 
 trait PurePersistentActor[Action, Effect, Response, State]
     extends PersistentActor
+    with AtLeastOnceDelivery
     with PureActor.Base[Action, Effect, Response, State] {
+  import PurePersistentActor._
 
   // ---- State
   private var state = initialState
   private def mutateState(effect: Effect): Unit = {
     state = updateState(state, effect)
+    deliverIfPropagatable(effect)
   }
 
-  // ---- Action/Effect Handling
-  private def receiveAction(action: Action): Unit = {
-    val (maybeResponse, effects) = handleAction(state, action)
-    persistAll(effects)(mutateState)
-    maybeResponse.foreach { response =>
-      deferAsync(response)(sender() ! _)
-    }
-    forwardEffects(effects)
-  }
-
-  private def forwardEffects(effects: List[Effect]): Unit = {
-    effects.foreach { effect =>
-      deferAsync(effect)(self.forward(_))
+  // ---- AtLeastOnceDelivery
+  // We're delivering the effect to ourselves, allowing us to replay unfinished
+  // effects after recovery.
+  private def deliverIfPropagatable(effect: Effect) = {
+    if (propagateEffect.isDefinedAt(effect)) {
+      deliver(self.path)(id => ConfirmableEffect(id, effect))
     }
   }
 
-  private def receiveEffect(effect: Effect): Unit = {
-    propagateEffect.lift(effect)
+  private def dispatchEffect(message: Any)(to: Effect => Unit) = {
+    wrapReceive(noOp, to)(message)
   }
 
+  private def receiveDelivery: Receive = {
+    case confirmation @ ConfirmedEffect(deliveryId) =>
+      persist(confirmation) { _ => confirmDelivery(deliveryId) }
+    case ConfirmableEffect(deliveryId, effect) =>
+      dispatchEffect(effect) { effect =>
+        propagateEffect.lift(effect)
+        self ! ConfirmedEffect(deliveryId)
+      }
+  }
+
+  private def receiveDeliveryRecover: Receive = {
+    case ConfirmedEffect(deliveryId) =>
+      confirmDelivery(deliveryId)
+  }
+
+  // ---- Internal Messages
   private def receiveInternal: Receive = {
     case PureActor.ProbeState => deferAsync(state)(sender() ! _)
   }
 
+  // ---- Action Handling
+  private def receiveAction(action: Action): Unit = {
+    val (maybeResponse, effects) = handleAction(state, action)
+    persistAll(effects)(mutateState)
+    respondToSender(maybeResponse)
+  }
+
+  private def respondToSender(maybeResponse: Option[Response]) = {
+    maybeResponse.foreach { response =>
+      deferAsync(response)(sender() ! _)
+    }
+  }
+
   // ---- Receive/Recover Logic
   private def generateReceiveCommand() =
-    wrapReceive(receiveAction, receiveEffect).orElse(receiveInternal)
+    wrapReceive(receiveAction, mutateState)
+      .orElse(receiveDelivery)
+      .orElse(receiveInternal)
 
   private def generateReceiveRecover() =
-    wrapReceive(_ => (), mutateState)
+    wrapReceive(noOp, mutateState)
+      .orElse(receiveDeliveryRecover)
 
   override def receiveCommand: Receive = generateReceiveCommand()
   override def receiveRecover: Receive = generateReceiveRecover()


### PR DESCRIPTION
This adjust effect propagation in the `PurePersistentActor`.

`AtLeastOnceDelivery` is used to the `deliver` the effect to the actor itself where it gets propagated and confirmed. This means that in the case of Actor termination unpropagated effects will be propagated once the Actor has recovered.

Additionally, `propagateEffect` now returns a `Future`, allowing for an async-first approach.