### PR TITLE
Ephemeral Effects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ lazy val akkaVersion = "2.5.3"
 
 scalacOptions ++= Seq(
   "-unchecked",
+  "-deprecation",
   "-feature",
   "-Ywarn-unused-import"
 )


### PR DESCRIPTION
There are effects that can or shall not be recovered after an actor shutdown. These can now be modelled using the `Ephemeral` trait and will cause a call to `deferAsync` instead of `persist`. Additionally, they are not guaranteed to be executed since they are not propagated via `deliver`.

For example, this way we can model asynchronous responses to `sender()` (which previously was a problem due to `sender()` not being meaningful during recovery). Or any kind of fire-and-forget task.